### PR TITLE
Fixes a performance issue when parsing DXF

### DIFF
--- a/core/src/main/java/org/kabeja/common/Layer.java
+++ b/core/src/main/java/org/kabeja/common/Layer.java
@@ -107,6 +107,10 @@ public class Layer {
     */
     
     public void setDocument(DraftDocument doc) {
+        if (this.doc != null && this.doc.equals(doc)) {
+            return;
+        }
+
         this.doc = doc;
         //add to all entities
         for(List<DraftEntity> list:entities.values()){


### PR DESCRIPTION
 when adding an entity to a Layer the parser sets the Document for this Layer (again), which sets the document for all Entities on that Layer (again). This is unnecessary and, for DXF files with many entities, very expensive.

@Reviewers: The entire thing looks a bit suspicious to me. Can you check if I'm assuming any preconditions that aren't true? E.g. I'm assuming that all entities that are already set on a layer have the right document set, and that we only want to re-set the document for all entities when it changes.
